### PR TITLE
suggestion -> a handy method to send and receive multiple API calls at once in a priority order

### DIFF
--- a/client/helper.go
+++ b/client/helper.go
@@ -1,0 +1,112 @@
+package client
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"sort"
+)
+
+type CallObject struct {
+	Priority int
+	Service  string
+	Endpoint string
+	Request  map[string]interface{}
+}
+
+type CallObjectResponse struct {
+	Priority int
+	Service  string
+	Endpoint string
+	Request  map[string]interface{}
+	Response interface{}
+	Err      error
+}
+
+// RQ stores requests and RS stores requests and thier responses
+type CallObjects struct {
+	RS []CallObjectResponse
+	RQ []CallObject
+}
+
+func NewCallObjects() *CallObjects {
+	return &CallObjects{
+		RS: []CallObjectResponse{},
+		RQ: []CallObject{},
+	}
+}
+
+// Implementing sort.Interface interface Len, Less and Swap
+func (co *CallObjects) Len() int {
+	return len(co.RQ)
+}
+
+func (co *CallObjects) Less(i, j int) bool {
+	return co.RQ[i].Priority < co.RQ[j].Priority
+}
+
+func (co *CallObjects) Swap(i, j int) {
+	co.RQ[i], co.RQ[j] = co.RQ[j], co.RQ[i]
+}
+
+// Put adds items(s)
+func (co *CallObjects) Put(items ...CallObject) {
+	co.RQ = append(co.RQ, items...)
+}
+
+// SortPriority sorts CallObjects by Priority
+func (co *CallObjects) SortPriority() {
+	sort.Sort(co)
+}
+
+// Get returns highest priority and remove it from CallObjects.RQ
+func (co *CallObjects) Get() (bool, CallObject) {
+	if len(co.RQ) == 0 {
+		return false, CallObject{}
+	}
+
+	// last element
+	i := len(co.RQ) - 1
+
+	obj := co.RQ[i]
+
+	co.RQ = co.RQ[0:i]
+
+	return true, obj
+}
+
+// Empty checks if CallObjects.RQ is empty
+func (co *CallObjects) Empty() bool {
+	return len(co.RQ) == 0
+}
+
+// CreateRequest creates a request for a CallObject
+func CreateRequest(co CallObject, client *Client) (*http.Request, error) {
+
+	uri, err := url.Parse(client.options.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	// set the url to go through the v1 api
+	uri.Path = "/v1/" + co.Service + "/" + co.Endpoint
+
+	b, err := marshalRequest(co.Service, co.Endpoint, co.Request)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", uri.String(), bytes.NewBuffer(b))
+	if err != nil {
+		return nil, err
+	}
+
+	// set the token if it exists
+	if len(client.options.Token) > 0 {
+		req.Header.Set("Authorization", "Bearer "+client.options.Token)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}


### PR DESCRIPTION
example:
```
package main

import (
  "fmt"
  "github.com/m3o/m3o-go/client"
)
    
func main() {
  c := client.NewClient(&client.Options{
    Token: "INSERT_YOUR_TOKEN_HERE",
  })

  co1 := client.CallObject{
		Priority: 100,
		Service:  "geocoding",
		Endpoint: "Reverse",
		Request: map[string]interface{}{
			"latitude":  43.5587995,
			"longitude": 39.77667659,
		},
	}

	co2 := client.CallObject{
		Priority: 20,
		Service:  "id",
		Endpoint: "Generate",
		Request: map[string]interface{}{
			"type": "uuid",
		},
	}

	co3 := client.CallObject{
		Priority: 50,
		Service:  "db",
		Endpoint: "Create",
		Request: map[string]interface{}{
			"record": map[string]interface{}{
				"name":     "debo7",
				"age":      42,
				"isActive": true,
				"address":  "xyz 123456",
			},
			"table": "users2",
		},
	}

	co4 := client.CallObject{
		Priority: 40,
		Service:  "db",
		Endpoint: "Create",
		Request: map[string]interface{}{
			"record": map[string]interface{}{
				"name":     "debo7",
				"age":      42,
				"isActive": true,
				"address":  "123456 xyz",
			},
			"table": "users2",
		},
	}

	callList := []client.CallObject{co2, co4, co1, co3}

	cos := client.NewCallObjects()
	cos.Put(callList...)

	cos = c.DisbatchAll(cos)

	for _, v := range cos.RS {
		fmt.Println("Priority", v.Priority)
		fmt.Println("Service", v.Service)
		fmt.Println("Endpoint", v.Endpoint)
		fmt.Println("Request", v.Request)
		fmt.Println("Response", v.Response)
		fmt.Println("Error", v.Err)
		fmt.Println("###########################################")
	}
}
```